### PR TITLE
Hardening disable

### DIFF
--- a/nixos/pkgs/golang.nix
+++ b/nixos/pkgs/golang.nix
@@ -70,6 +70,8 @@ in stdenv.mkDerivation {
       }
       change_owner
 
+      export NIX_HARDENING_ENABLE=""
+
     '';
 
     # set/unset `NIX_HARDENING_ENABLE` env var; https://stackoverflow.com/a/27719330/2768067

--- a/nixos/pkgs/golang.nix
+++ b/nixos/pkgs/golang.nix
@@ -71,4 +71,18 @@ in stdenv.mkDerivation {
       change_owner
 
     '';
+
+    # set/unset `NIX_HARDENING_ENABLE` env var; https://stackoverflow.com/a/27719330/2768067
+    # We need to unset this because `delve` debugger is failing to debug with some error.
+    #     ```
+    #     runtime/cgo
+    #     warning _FORTIFY_SOURCE requires compiling with optimization (-O)
+    #         |    ^~~~~~~
+    #     cc1: all warnings being treated as errors
+    #     exit status 2
+    #     ```
+    # see issue: https://github.com/NixOS/nixpkgs/issues/18995
+    # also see PR: https://github.com/NixOS/nixpkgs/pull/28029/files on how it is set
+    # and its default value
+    NIX_HARDENING_ENABLE="";
 }

--- a/nixos/pkgs/preRequiste.nix
+++ b/nixos/pkgs/preRequiste.nix
@@ -1,9 +1,6 @@
 with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/21.05.tar.gz") {});
 
 let
-    # https://nixos.org/guides/declarative-and-reproducible-developer-environments.html#declarative-reproducible-envs
-    LC_ALL = "en_US.UTF-8";
-    SOME_CUSTOM_ENV_VAR = "hello there";
 
 in stdenv.mkDerivation {
     name = "preRequistes";
@@ -25,4 +22,11 @@ in stdenv.mkDerivation {
       CURL_CA_BUNDLE=$(find /nix -name ca-bundle.crt |tail -n 1)
       export CURL_CA_BUNDLE="$CURL_CA_BUNDLE"
     '';
+
+    # set some env vars.
+    # https://nixos.org/guides/declarative-and-reproducible-developer-environments.html#declarative-reproducible-envs
+    # https://stackoverflow.com/a/27719330/2768067
+    LC_ALL = "en_US.UTF-8";
+    SOME_CUSTOM_ENV_VAR = "hello there";
+
 }

--- a/nixos/pkgs/preRequiste.nix
+++ b/nixos/pkgs/preRequiste.nix
@@ -21,12 +21,14 @@ in stdenv.mkDerivation {
 
       CURL_CA_BUNDLE=$(find /nix -name ca-bundle.crt |tail -n 1)
       export CURL_CA_BUNDLE="$CURL_CA_BUNDLE"
+
+      export SOME_CUSTOM_ENV_VAR="hello_there"
     '';
 
     # set some env vars.
     # https://nixos.org/guides/declarative-and-reproducible-developer-environments.html#declarative-reproducible-envs
     # https://stackoverflow.com/a/27719330/2768067
     LC_ALL = "en_US.UTF-8";
-    SOME_CUSTOM_ENV_VAR = "hello there";
+    SOME_CUSTOM_ENV_VAR = "hello_there";
 
 }


### PR DESCRIPTION
set/unset `NIX_HARDENING_ENABLE` env var; https://stackoverflow.com/a/27719330/2768067
We need to unset this because `delve` debugger is failing to debug with some error.
    ```
    runtime/cgo
    warning _FORTIFY_SOURCE requires compiling with optimization (-O)
        |    ^~~~~~~
    cc1: all warnings being treated as errors
    exit status 2
    ```
see issue: https://github.com/NixOS/nixpkgs/issues/18995
also see PR: https://github.com/NixOS/nixpkgs/pull/28029/files on how it is set