### PR TITLE
update to use the latest NixOS/nixpkgs commit.

### DIFF
--- a/nixos/config.nixpkgs.config.nix
+++ b/nixos/config.nixpkgs.config.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/21.05.tar.gz") {} }:
+{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b56d7a70a7158f81d964a55cfeb78848a067cc7d.tar.gz") {} }:
 
 {
 # The time zone used when displaying times and dates. 

--- a/nixos/pkgs/c_lang.nix
+++ b/nixos/pkgs/c_lang.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/21.05.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b56d7a70a7158f81d964a55cfeb78848a067cc7d.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/dart.nix
+++ b/nixos/pkgs/dart.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/21.05.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b56d7a70a7158f81d964a55cfeb78848a067cc7d.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/default.nix
+++ b/nixos/pkgs/default.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/21.05.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b56d7a70a7158f81d964a55cfeb78848a067cc7d.tar.gz") {});
 
 /*
   Alternative are:

--- a/nixos/pkgs/dns.nix
+++ b/nixos/pkgs/dns.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/21.05.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b56d7a70a7158f81d964a55cfeb78848a067cc7d.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/docker.nix
+++ b/nixos/pkgs/docker.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/21.05.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b56d7a70a7158f81d964a55cfeb78848a067cc7d.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/golang.nix
+++ b/nixos/pkgs/golang.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/21.05.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b56d7a70a7158f81d964a55cfeb78848a067cc7d.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/jb.nix
+++ b/nixos/pkgs/jb.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/e824324fd57be1485efc14d4d308e8f1bfc15d47.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b56d7a70a7158f81d964a55cfeb78848a067cc7d.tar.gz") {});
 # we need some specific versions of helm, kind, skaffold that are not available in version 21.05
 # TODO: go back to tagged version once the three packages get updated.
 

--- a/nixos/pkgs/oh_my_zsh.nix
+++ b/nixos/pkgs/oh_my_zsh.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/21.05.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b56d7a70a7158f81d964a55cfeb78848a067cc7d.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/preRequiste.nix
+++ b/nixos/pkgs/preRequiste.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/21.05.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b56d7a70a7158f81d964a55cfeb78848a067cc7d.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/provision.nix
+++ b/nixos/pkgs/provision.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/21.05.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b56d7a70a7158f81d964a55cfeb78848a067cc7d.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/setup_ssh.nix
+++ b/nixos/pkgs/setup_ssh.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/21.05.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b56d7a70a7158f81d964a55cfeb78848a067cc7d.tar.gz") {});
 
 let
     # TODO: should we have a different passphrase per key?

--- a/nixos/pkgs/terminal.nix
+++ b/nixos/pkgs/terminal.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/21.05.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b56d7a70a7158f81d964a55cfeb78848a067cc7d.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/tools.nix
+++ b/nixos/pkgs/tools.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/21.05.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b56d7a70a7158f81d964a55cfeb78848a067cc7d.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/version_control.nix
+++ b/nixos/pkgs/version_control.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/21.05.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b56d7a70a7158f81d964a55cfeb78848a067cc7d.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/vscode.nix
+++ b/nixos/pkgs/vscode.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/21.05.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b56d7a70a7158f81d964a55cfeb78848a067cc7d.tar.gz") {});
 
 let
 


### PR DESCRIPTION
update to use the latest NixOS/nixpkgs commit.

this is because, somethings like google-chrome are already outdated.
we need to use the latest versions of these