### PR TITLE
Go1.18

### DIFF
--- a/nixos/config.nixpkgs.config.nix
+++ b/nixos/config.nixpkgs.config.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {} }:
+{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/81a80c69f716a5b782f2ab65e9eb38b7557ffb01.tar.gz") {} }:
 
 {
 # The time zone used when displaying times and dates. 

--- a/nixos/config.nixpkgs.config.nix
+++ b/nixos/config.nixpkgs.config.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {} }:
+{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {} }:
 
 {
 # The time zone used when displaying times and dates. 

--- a/nixos/config.nixpkgs.config.nix
+++ b/nixos/config.nixpkgs.config.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/5167a4a283b4286e62ee8a95ffa0f69c88a9b8d3.tar.gz") {} }:
+{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {} }:
 
 {
 # The time zone used when displaying times and dates. 

--- a/nixos/pkgs/c_lang.nix
+++ b/nixos/pkgs/c_lang.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/81a80c69f716a5b782f2ab65e9eb38b7557ffb01.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/c_lang.nix
+++ b/nixos/pkgs/c_lang.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/c_lang.nix
+++ b/nixos/pkgs/c_lang.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/5167a4a283b4286e62ee8a95ffa0f69c88a9b8d3.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/dart.nix
+++ b/nixos/pkgs/dart.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/81a80c69f716a5b782f2ab65e9eb38b7557ffb01.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/dart.nix
+++ b/nixos/pkgs/dart.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/dart.nix
+++ b/nixos/pkgs/dart.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/5167a4a283b4286e62ee8a95ffa0f69c88a9b8d3.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/default.nix
+++ b/nixos/pkgs/default.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/5167a4a283b4286e62ee8a95ffa0f69c88a9b8d3.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {});
 
 /*
   Alternative are:

--- a/nixos/pkgs/default.nix
+++ b/nixos/pkgs/default.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {});
 
 /*
   Alternative are:

--- a/nixos/pkgs/default.nix
+++ b/nixos/pkgs/default.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/81a80c69f716a5b782f2ab65e9eb38b7557ffb01.tar.gz") {});
 
 /*
   Alternative are:

--- a/nixos/pkgs/dns.nix
+++ b/nixos/pkgs/dns.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/81a80c69f716a5b782f2ab65e9eb38b7557ffb01.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/dns.nix
+++ b/nixos/pkgs/dns.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/dns.nix
+++ b/nixos/pkgs/dns.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/5167a4a283b4286e62ee8a95ffa0f69c88a9b8d3.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/docker.nix
+++ b/nixos/pkgs/docker.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/81a80c69f716a5b782f2ab65e9eb38b7557ffb01.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/docker.nix
+++ b/nixos/pkgs/docker.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/docker.nix
+++ b/nixos/pkgs/docker.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/5167a4a283b4286e62ee8a95ffa0f69c88a9b8d3.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/golang.nix
+++ b/nixos/pkgs/golang.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/81a80c69f716a5b782f2ab65e9eb38b7557ffb01.tar.gz") {});
 
 let
 
@@ -21,7 +21,9 @@ in stdenv.mkDerivation {
     hardeningDisable = [ "all" ];
 
     buildInputs = [
-        pkgs.go
+        # We do not use the one from nixpkgs since they usually take a lot of
+        # time before updating to the latest Go version.
+        # pkgs.go
       ];
 
     shellHook = ''
@@ -32,6 +34,21 @@ in stdenv.mkDerivation {
       printf "\n running hooks for golang.nix \n"
 
       MY_NAME=$(whoami)
+
+      install_latest_golang(){
+          golang_bin_file="/usr/local/go/bin/go"
+          if [ -f "$golang_bin_file" ]; then
+              # bin file exists
+              echo -n ""
+          else
+              GOLANG_VERSION=go1.18.linux-amd64
+              sudo rm -rf "/usr/local/$GOLANG_VERSION.tar.gz"
+              sudo rm -rf /usr/local/go
+              sudo wget -nc --output-document="/usr/local/$GOLANG_VERSION.tar.gz" "https://go.dev/dl/$GOLANG_VERSION.tar.gz"
+              sudo tar -xzf "/usr/local/$GOLANG_VERSION.tar.gz" -C /usr/local/
+          fi
+      }
+      install_latest_golang
 
       install_go_pkgs(){
           curlie_bin_file="/home/$MY_NAME/go/bin/curlie"

--- a/nixos/pkgs/golang.nix
+++ b/nixos/pkgs/golang.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/golang.nix
+++ b/nixos/pkgs/golang.nix
@@ -46,6 +46,7 @@ in stdenv.mkDerivation {
               sudo rm -rf /usr/local/go
               sudo wget -nc --output-document="/usr/local/$GOLANG_VERSION.tar.gz" "https://go.dev/dl/$GOLANG_VERSION.tar.gz"
               sudo tar -xzf "/usr/local/$GOLANG_VERSION.tar.gz" -C /usr/local/
+              sudo ln --force --symbolic /usr/local/go/bin/go /usr/local/bin/go
           fi
       }
       install_latest_golang

--- a/nixos/pkgs/golang.nix
+++ b/nixos/pkgs/golang.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/5167a4a283b4286e62ee8a95ffa0f69c88a9b8d3.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/jb.nix
+++ b/nixos/pkgs/jb.nix
@@ -1,5 +1,6 @@
 with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/e824324fd57be1485efc14d4d308e8f1bfc15d47.tar.gz") {});
 # we need some specific versions of helm, kind, skaffold that are not available in version 21.05
+# That is why we are using nixpkgs at commit e824324f
 # specificallly:
 #    helm version:
 #      v3.6.3

--- a/nixos/pkgs/jb.nix
+++ b/nixos/pkgs/jb.nix
@@ -44,8 +44,10 @@ in stdenv.mkDerivation {
         pkgs.mongodb-tools
         pkgs.bridge-utils
         pkgs.iptables
-        pkgs.go_1_17 # remember to update the add_go_17() bash function.
-        pkgs.go_1_16 # remember to update the add_go_16() bash function.
+        # Do not use the various Go versions from nixPkgs.
+        # They clash with the one installed via pkgs/golang.nix
+        # pkgs.go_1_17
+        # pkgs.go_1_16
         pkgs.jetbrains.goland
         pkgs.nodePackages.npm
         pkgs.yarn
@@ -230,29 +232,35 @@ in stdenv.mkDerivation {
         }
         install_mongo_shell
 
-        add_go_17(){
+        install_go_17(){
             linked_file="/usr/local/bin/go17"
             if [ -f "$linked_file" ]; then
                 # exists
                 echo -n ""
             else
-                bin_file="$(find /nix -name "*go-1.17.1")/bin/go"
-                sudo ln --force --symbolic $bin_file /usr/local/bin/go17
+                GOLANG_VERSION=go1.17.1.linux-amd64
+                wget -nc --output-document="/tmp/$GOLANG_VERSION.tar.gz" "https://go.dev/dl/$GOLANG_VERSION.tar.gz"
+                mkdir -p /tmp/go17
+                tar -xzf "/tmp/$GOLANG_VERSION.tar.gz" -C /tmp/go17
+                sudo cp /tmp/go17/go/bin/go /usr/local/bin/go17
             fi
         }
-        add_go_17
+        install_go_17
 
-        add_go_16(){
+        install_go_16(){
             linked_file="/usr/local/bin/go16"
             if [ -f "$linked_file" ]; then
                 # exists
                 echo -n ""
             else
-                bin_file="$(find /nix -name "*go-1.16.8")/bin/go"
-                sudo ln --force --symbolic $bin_file /usr/local/bin/go16
+                GOLANG_VERSION=go1.16.8.linux-amd64
+                wget -nc --output-document="/tmp/$GOLANG_VERSION.tar.gz" "https://go.dev/dl/$GOLANG_VERSION.tar.gz"
+                mkdir -p /tmp/go16
+                tar -xzf "/tmp/$GOLANG_VERSION.tar.gz" -C /tmp/go16
+                sudo cp /tmp/go16/go/bin/go /usr/local/bin/go16
             fi
         }
-        add_go_16
+        install_go_16
 
         install_jb_go_pkgs(){
             structslop_bin_file="/home/$MY_NAME/go/bin/structslop"

--- a/nixos/pkgs/jb.nix
+++ b/nixos/pkgs/jb.nix
@@ -44,8 +44,8 @@ in stdenv.mkDerivation {
         pkgs.mongodb-tools
         pkgs.bridge-utils
         pkgs.iptables
+        pkgs.go_1_17 # remember to update the add_go_17() bash function.
         pkgs.go_1_16 # remember to update the add_go_16() bash function.
-        pkgs.go_1_15 # remember to update the add_go_15() bash function.
         pkgs.jetbrains.goland
         pkgs.nodePackages.npm
         pkgs.yarn
@@ -230,6 +230,18 @@ in stdenv.mkDerivation {
         }
         install_mongo_shell
 
+        add_go_17(){
+            linked_file="/usr/local/bin/go17"
+            if [ -f "$linked_file" ]; then
+                # exists
+                echo -n ""
+            else
+                bin_file="$(find /nix -name "*go-1.17.7")/bin/go"
+                sudo ln --force --symbolic $bin_file /usr/local/bin/go17
+            fi
+        }
+        add_go_17
+
         add_go_16(){
             linked_file="/usr/local/bin/go16"
             if [ -f "$linked_file" ]; then
@@ -241,18 +253,6 @@ in stdenv.mkDerivation {
             fi
         }
         add_go_16
-
-        add_go_15(){
-            linked_file="/usr/local/bin/go15"
-            if [ -f "$linked_file" ]; then
-                # exists
-                echo -n ""
-            else
-                bin_file="$(find /nix -name "*go-1.15.15")/bin/go"
-                sudo ln --force --symbolic $bin_file /usr/local/bin/go15
-            fi
-        }
-        add_go_15
 
         install_jb_go_pkgs(){
             structslop_bin_file="/home/$MY_NAME/go/bin/structslop"

--- a/nixos/pkgs/jb.nix
+++ b/nixos/pkgs/jb.nix
@@ -236,7 +236,7 @@ in stdenv.mkDerivation {
                 # exists
                 echo -n ""
             else
-                bin_file="$(find /nix -name "*go-1.17.7")/bin/go"
+                bin_file="$(find /nix -name "*go-1.17.1")/bin/go"
                 sudo ln --force --symbolic $bin_file /usr/local/bin/go17
             fi
         }

--- a/nixos/pkgs/oh_my_zsh.nix
+++ b/nixos/pkgs/oh_my_zsh.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/81a80c69f716a5b782f2ab65e9eb38b7557ffb01.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/oh_my_zsh.nix
+++ b/nixos/pkgs/oh_my_zsh.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/oh_my_zsh.nix
+++ b/nixos/pkgs/oh_my_zsh.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/5167a4a283b4286e62ee8a95ffa0f69c88a9b8d3.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/preRequiste.nix
+++ b/nixos/pkgs/preRequiste.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/81a80c69f716a5b782f2ab65e9eb38b7557ffb01.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/preRequiste.nix
+++ b/nixos/pkgs/preRequiste.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/preRequiste.nix
+++ b/nixos/pkgs/preRequiste.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/5167a4a283b4286e62ee8a95ffa0f69c88a9b8d3.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/provision.nix
+++ b/nixos/pkgs/provision.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {});
 
 let
 
@@ -11,7 +11,8 @@ in stdenv.mkDerivation {
         pkgs.kdiff3
         pkgs.meld
         pkgs.lsof
-        pkgs.telnet
+        # inetutils provides the following tools: ftp, hostname, ifconfig, ping, telnet, traceroute, whois, etc.
+        pkgs.inetutils
         pkgs.htop
         # `unrar` has an unfree LICENSE. By default, nix refuses to install it.
         #  We can force nix to install by setting env var `export NIXPKGS_ALLOW_UNFREE=1` or `allowUnfree` in `~/.config/nixpkgs/config.nix`
@@ -29,9 +30,7 @@ in stdenv.mkDerivation {
         pkgs.hexchat
         pkgs.mosh
         pkgs.eternal-terminal
-        pkgs.vnstat
         pkgs.psmisc
-        pkgs.traceroute
         pkgs.graphviz
         pkgs.ffmpeg
         pkgs.x264

--- a/nixos/pkgs/provision.nix
+++ b/nixos/pkgs/provision.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/81a80c69f716a5b782f2ab65e9eb38b7557ffb01.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/provision.nix
+++ b/nixos/pkgs/provision.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/5167a4a283b4286e62ee8a95ffa0f69c88a9b8d3.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/setup_ssh.nix
+++ b/nixos/pkgs/setup_ssh.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/81a80c69f716a5b782f2ab65e9eb38b7557ffb01.tar.gz") {});
 
 let
     # TODO: should we have a different passphrase per key?

--- a/nixos/pkgs/setup_ssh.nix
+++ b/nixos/pkgs/setup_ssh.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/5167a4a283b4286e62ee8a95ffa0f69c88a9b8d3.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {});
 
 let
     # TODO: should we have a different passphrase per key?

--- a/nixos/pkgs/setup_ssh.nix
+++ b/nixos/pkgs/setup_ssh.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {});
 
 let
     # TODO: should we have a different passphrase per key?

--- a/nixos/pkgs/terminal.nix
+++ b/nixos/pkgs/terminal.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/81a80c69f716a5b782f2ab65e9eb38b7557ffb01.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/terminal.nix
+++ b/nixos/pkgs/terminal.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/terminal.nix
+++ b/nixos/pkgs/terminal.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/5167a4a283b4286e62ee8a95ffa0f69c88a9b8d3.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/tools.nix
+++ b/nixos/pkgs/tools.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/81a80c69f716a5b782f2ab65e9eb38b7557ffb01.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/tools.nix
+++ b/nixos/pkgs/tools.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/tools.nix
+++ b/nixos/pkgs/tools.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/5167a4a283b4286e62ee8a95ffa0f69c88a9b8d3.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/version_control.nix
+++ b/nixos/pkgs/version_control.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/81a80c69f716a5b782f2ab65e9eb38b7557ffb01.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/version_control.nix
+++ b/nixos/pkgs/version_control.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/version_control.nix
+++ b/nixos/pkgs/version_control.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/5167a4a283b4286e62ee8a95ffa0f69c88a9b8d3.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/vscode.nix
+++ b/nixos/pkgs/vscode.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/81a80c69f716a5b782f2ab65e9eb38b7557ffb01.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/vscode.nix
+++ b/nixos/pkgs/vscode.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/2eb46d5c50448d30f3ac94c8fcb1f3c0f6732352.tar.gz") {});
 
 let
 

--- a/nixos/pkgs/vscode.nix
+++ b/nixos/pkgs/vscode.nix
@@ -1,4 +1,4 @@
-with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/5167a4a283b4286e62ee8a95ffa0f69c88a9b8d3.tar.gz") {});
+with (import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b734f40478ecf7d9557bea10473f2023b41956f8.tar.gz") {});
 
 let
 

--- a/templates/docker_systemd_service_file
+++ b/templates/docker_systemd_service_file
@@ -20,7 +20,7 @@ Environment="THE_DOCKERD_PATH=$(which dockerd)"
 # We should ideally use something like `$(which dockerd)`; but that aint working as of now.
 # Idea: run `find /nix -name "*docker*.service*"` all we need to do is symlink the docker.service file that we find
 # That service file comes with the `ExecStart` set to point to the correct dockerd
-ExecStart=/nix/store/2qwysmkjaizpsv412z6vvav6394zyd45-docker-20.10.12/bin/dockerd -H fd://
+ExecStart=/nix/store/67hb7vb4kqr5wikmkb4ln4d9wflnc5sx-docker-20.10.13/bin/dockerd -H fd://
 ExecReload=/bin/kill -s HUP $MAINPID
 
 LimitNOFILE=1048576


### PR DESCRIPTION
**TODO:** 
- remeber to update docker `templates/docker_systemd_service_file`
- Go 1.18 isn't default yet, wait for that to happen, see: https://search.nixos.org/packages?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=go