### PR TITLE
Add microsoft teams for linux.

### DIFF
--- a/pkgs/jb.nix
+++ b/pkgs/jb.nix
@@ -30,6 +30,7 @@ in stdenv.mkDerivation {
         pkgs.jq
         pkgs.kubectl
         pkgs.nodejs_23 # will also install npm
+        pkgs.teams-for-linux
 
         skaffoldImport.skaffold
         helmImport.kubernetes-helm-wrapped


### PR DESCRIPTION
Add microsoft teams for linux; its an un-official package. MS no longer provides official one for linux